### PR TITLE
Add content_guard option to Maven distribution commands

### DIFF
--- a/CHANGES/162.bugfix
+++ b/CHANGES/162.bugfix
@@ -1,0 +1,1 @@
+Added `--content-guard` option to Maven distribution `create` and `update` commands.

--- a/CHANGES/162.bugfix
+++ b/CHANGES/162.bugfix
@@ -1,1 +1,1 @@
-Added `--content-guard` option to Maven distribution `create` and `update` commands.
+Added missing `--content-guard` option to Maven distribution commands.

--- a/src/pulpcore/cli/maven/distribution.py
+++ b/src/pulpcore/cli/maven/distribution.py
@@ -2,6 +2,7 @@ import click
 from pulpcore.cli.common.generic import (
     PulpCLIContext,
     common_distribution_create_options,
+    content_guard_option,
     create_command,
     destroy_command,
     distribution_filter_options,
@@ -77,6 +78,7 @@ nested_lookup_options = [distribution_lookup_option]
 update_options = [
     remote_option,
     repository_option,
+    content_guard_option,
     pulp_labels_option,
 ]
 create_options = common_distribution_create_options + update_options


### PR DESCRIPTION
## Summary

- Adds `--content-guard` option to `pulp maven distribution create` and `pulp maven distribution update` commands
- The REST API already supports `content_guard` on Maven distributions (inherited from pulpcore's base DistributionSerializer), but the CLI was not exposing it
- Follows the same pattern used by the RPM distribution CLI

## Test plan

- [ ] `pulp maven distribution create --help` shows `--content-guard`
- [ ] `pulp maven distribution update --help` shows `--content-guard`
- [ ] Create a Maven distribution with a content guard assigned
- [ ] Update an existing Maven distribution to add/change a content guard

Fixes https://github.com/pulp/pulp-cli-maven/issues/162

🤖 Generated with [Claude Code](https://claude.com/claude-code)