### PR TITLE
[0.5] Backport: Add content_guard option to Maven distribution commands

### DIFF
--- a/CHANGES/162.bugfix
+++ b/CHANGES/162.bugfix
@@ -1,0 +1,1 @@
+Added missing `--content-guard` option to Maven distribution commands.

--- a/src/pulpcore/cli/maven/distribution.py
+++ b/src/pulpcore/cli/maven/distribution.py
@@ -2,6 +2,7 @@ import click
 from pulpcore.cli.common.generic import (
     PulpCLIContext,
     common_distribution_create_options,
+    content_guard_option,
     create_command,
     destroy_command,
     distribution_filter_options,
@@ -77,6 +78,7 @@ nested_lookup_options = [distribution_lookup_option]
 update_options = [
     remote_option,
     repository_option,
+    content_guard_option,
     pulp_labels_option,
 ]
 create_options = common_distribution_create_options + update_options


### PR DESCRIPTION
## Summary

Backport of #160 to the 0.5 branch.

Adds the missing `--content-guard` option to Maven distribution `create` and `update` commands.

Fixes https://github.com/pulp/pulp-cli-maven/issues/162